### PR TITLE
Error handling refactor, platform logos client, media resources read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to igdb-rs will be documented in this file.
 
+# [0.1.0] - 2019-08-26
+
+## Changes
+
+- Refactor internal error handling
+- Add platform logos client
+- Add get_resource_by_id in media macros to retrieve media as bytes buffers
+- Add read media and platform logos download samples
+
 # [0.0.24] - 2019-08-26
 
 ## Changes
@@ -20,3 +29,4 @@ All notable changes to igdb-rs will be documented in this file.
 
 [0.0.23]: https://github.com/carloslanderas/igdb-rs/compare/0.0.22...0.0.23
 [0.0.24]: https://github.com/carloslanderas/igdb-rs/compare/0.0.23...0.0.24
+[0.1.0]: https://github.com/carloslanderas/igdb-rs/compare/0.0.24...0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "igdb-rs"
-version = "0.0.24"
+version = "0.1.0"
 dependencies = [
  "async-std 0.99.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "femme 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "igdb-rs"
-version = "0.0.24"
+version = "0.1.0"
 authors = ["Carlos Landeras"]
 edition = "2018"
 license = "Apache-2.0/MIT"
@@ -33,8 +33,11 @@ path = "examples/search_first_game_by_name.rs"
 name = "search-games-by-name"
 path = "examples/search_games_by_name.rs"
 [[example]]
-name = "download-game-images"
-path = "examples/download_game_images.rs"
+name = "game-media-download"
+path = "examples/game_media_download.rs"
+[[example]]
+name = "game-media-read"
+path = "examples/game_media_read.rs"
 [[example]]
 name = "request-builder-multiplayer"
 path = "examples/request_builder_multiplayer.rs"
@@ -50,6 +53,9 @@ path = "examples/game_video_urls.rs"
 [[example]]
 name = "game-platforms"
 path = "examples/game_platforms.rs"
+[[example]]
+name ="game-platforms-logos"
+path = "examples/game_platforms_logos.rs"
 [[example]]
 name = "game-release-date"
 path = "examples/game_release_date.rs"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ igdb-rs supports the following endpoints at this moment:
 | Franchises | A list of video game franchises such as Star Wars.|
 | Multiplayer Modes | Data about the supported multiplayer types|
 | Platforms |  The hardware used to run the game or game delivery network |
+| Platform Logo | Logo for a platform |
 | Player Perspectives | Player perspectives describe the view/perspective of the player in a video game|
 | Release Dates |  A handy endpoint that extends game release dates. Used to dig deeper into release dates, platforms and versions. |
 | Screenshots | Screenshots of games |

--- a/examples/game_media_download.rs
+++ b/examples/game_media_download.rs
@@ -4,6 +4,10 @@ use igdb_rs::media_quality::MediaQuality;
 
 fn main() {
     task::block_on(async {
+        // All media clients like screenshots, covers, artworks, etc can be downloaded to disk
+        // by using download_by_id method
+        // Yoy can also read them as a bytes buffer, (game_media_read sample)
+
         let igdb_client = IGDBClient::new("user-key");
         let games_client = igdb_client.games();
         let witcher = games_client.get_first_by_name("Witcher 3").await.unwrap();
@@ -19,9 +23,13 @@ fn main() {
             .await
             .unwrap();
 
+        //Get the first 3 artworks for the Witcher 3 game
+        let artworks_client = igdb_client.artworks();
+        let artworks_response = artworks_client.get_by_game_id(witcher.id, 3).await.unwrap();
+
         for (i, cover) in covers_response.iter().enumerate() {
             covers_client
-                .download_by_id(cover.id, format!("cover{}.jpg", i), MediaQuality::CoverBig)
+                .download_by_id(cover.id, format!("cover{}.jpg", i), MediaQuality::Original)
                 .await
                 .unwrap();
         }
@@ -33,6 +41,13 @@ fn main() {
                     format!("screenshot{}.jpg", i),
                     MediaQuality::ScreenshotHuge,
                 )
+                .await
+                .unwrap();
+        }
+
+        for (i, artwork) in artworks_response.iter().enumerate() {
+            artworks_client
+                .download_by_id(artwork.id, format!("artwork{}.jpg", i), MediaQuality::HD)
                 .await
                 .unwrap();
         }

--- a/examples/game_media_read.rs
+++ b/examples/game_media_read.rs
@@ -1,0 +1,35 @@
+use async_std::task;
+use igdb_rs::client::IGDBClient;
+use igdb_rs::media_quality::MediaQuality;
+use std::io::Write;
+
+fn main() {
+    task::block_on(async {
+        // All media clients like screenshots, covers, artworks, etc can read resources as bytes
+        // by using get_resource_by_id method
+        // Yoy can also directly download them to disk, (game_media_download sample)
+
+        let igdb_client = IGDBClient::new("user-key");
+        let games_client = igdb_client.games();
+        let witcher = games_client.get_first_by_name("Witcher 3").await.unwrap();
+
+        //Get the first 3 screenshots for the Witcher 3 game
+        let screenshots_client = igdb_client.screenshots();
+        let screenshots_response = screenshots_client
+            .get_by_game_id(witcher.id, 3)
+            .await
+            .unwrap();
+
+        for screen in screenshots_response {
+            let bytes = screenshots_client
+                .get_resource_by_id(screen.id, MediaQuality::FullHD)
+                .await
+                .unwrap();
+
+            debug_assert!(bytes.len() > 0);
+
+            let mut f = std::fs::File::create(format!("{}.jpg", screen.id)).unwrap();
+            f.write_all(&bytes).unwrap();
+        }
+    })
+}

--- a/examples/game_platforms_logos.rs
+++ b/examples/game_platforms_logos.rs
@@ -1,0 +1,33 @@
+use async_std::task;
+use igdb_rs::client::IGDBClient;
+use igdb_rs::media_quality::MediaQuality;
+
+fn main() {
+    femme::start(log::LevelFilter::Debug).unwrap();
+
+    task::block_on(async {
+        let igdb_client = IGDBClient::new("user-key");
+
+        let games_client = igdb_client.games();
+        let game = games_client.get_first_by_name("Borderlands 2").await.unwrap();
+
+        let platforms_client = igdb_client.platforms();
+        let platform_logos_client = igdb_client.platform_logos();
+
+        for p_id in game.platforms {
+            let platform = platforms_client
+                .get_first_by_id(p_id as usize)
+                .await
+                .unwrap();
+
+            platform_logos_client
+                .download_by_id(
+                    platform.platform_logo,
+                    format!("{}.png", platform.name),
+                    MediaQuality::Original,
+                )
+                .await
+                .unwrap();
+        }
+    })
+}

--- a/examples/game_platforms_logos.rs
+++ b/examples/game_platforms_logos.rs
@@ -9,7 +9,10 @@ fn main() {
         let igdb_client = IGDBClient::new("user-key");
 
         let games_client = igdb_client.games();
-        let game = games_client.get_first_by_name("Borderlands 2").await.unwrap();
+        let game = games_client
+            .get_first_by_name("Borderlands 2")
+            .await
+            .unwrap();
 
         let platforms_client = igdb_client.platforms();
         let platform_logos_client = igdb_client.platform_logos();

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,7 @@ create_client!(EnginesClient, Engine, game_engines);
 create_client!(FranchisesClient, Franchise, franchises);
 create_client!(MultiPlayerModesClient, MultiplayerMode, multiplayer_modes);
 create_client!(PlatformsClient, Platform, platforms);
+create_client!(PlatformLogosClient, PlatformLogo, platform_logos);
 create_client!(
     PlayerPerpectivesClient,
     PlayerPerspective,
@@ -29,6 +30,7 @@ create_client!(WebsitesClient, Website, websites);
 expand_media_download!(ArtworksClient);
 expand_media_download!(CoversClient);
 expand_media_download!(ScreenshotsClient);
+expand_media_download!(PlatformLogosClient);
 
 expand_get_by_game_id!(ArtworksClient, Artwork);
 expand_get_by_game_id!(CoversClient, Cover);
@@ -76,31 +78,4 @@ impl IGDBClient {
     pub fn create_request() -> RequestBuilder {
         RequestBuilder::new()
     }
-}
-
-#[allow(dead_code)]
-///This function receives a path, an IGDB provided url and it normalices the path and downloads
-/// the resource to the specified path file using the specified MediaQuality"
-async fn download_resource(
-    path: String,
-    url: String,
-    quality: MediaQuality,
-) -> Result<(), std::io::Error> {
-    use async_std::fs::File;
-    use async_std::io::Write;
-
-    let mut parsed_url = match url {
-        _ if !url.starts_with("http") => format!("{}{}", "http:", url),
-        _ => url.to_owned(),
-    };
-
-    parsed_url = parsed_url.replace("thumb", &quality.get_value());
-
-    log::debug!("Downloading resource: {}", parsed_url);
-
-    let content = surf::get(parsed_url).recv_bytes().await.unwrap();
-    let mut file = File::create(path).await?;
-    file.write(&content[..]).await.unwrap();
-
-    Ok(())
 }

--- a/src/client_macros.rs
+++ b/src/client_macros.rs
@@ -20,12 +20,17 @@ macro_rules! create_client {
                 self.get(request).await
             }
             /// Returns the element by Id for this client in Option<T> format.
-            pub async fn get_first_by_id(&self, id: usize) -> Option<$j> {
+            pub async fn get_first_by_id(&self, id: usize) -> Result<$j, Error> {
                 match self.get_by_id(id, 1).await {
-                    Ok(d) => Some(d[0].clone()),
+                    Ok(ref d) if !d.is_empty() => Ok(d[0].clone()),
+                    Ok(_) => Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Empty response from server for query with id: {}", id),
+                    )
+                    .into()),
                     Err(e) => {
                         log::error!("{}", e);
-                        None
+                        Err(e)
                     }
                 }
             }
@@ -80,9 +85,10 @@ macro_rules! use_client_imports {
             model::company::Company, model::cover::Cover, model::engine::Engine,
             model::franchise::Franchise, model::game_mode::GameMode, model::game_video::GameVideo,
             model::games::Game, model::multiplayer_mode::MultiplayerMode,
-            model::platform::Platform, model::player_perspective::PlayerPerspective,
-            model::release_date::ReleaseDate, model::screenshot::Screenshot, model::theme::Theme,
-            model::website::Website, request_builder::Equality, request_builder::RequestBuilder,
+            model::platform::Platform, model::platform_logo::PlatformLogo,
+            model::player_perspective::PlayerPerspective, model::release_date::ReleaseDate,
+            model::screenshot::Screenshot, model::theme::Theme, model::website::Website,
+            request_builder::Equality, request_builder::RequestBuilder,
         };
 
         use crate::Error;

--- a/src/endpoint_client.rs
+++ b/src/endpoint_client.rs
@@ -22,8 +22,8 @@ impl EndpointClient {
 
         match response {
             Ok(ref mut resp) => {
-                let response_str: String = resp.body_string().await.unwrap();
-                Ok(serde_json::from_str::<Vec<T>>(&response_str).unwrap())
+                let response_str: String = resp.body_string().await?;
+                Ok(serde_json::from_str::<Vec<T>>(&response_str)?)
             }
             Err(e) => {
                 log::error!("{}", e);

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -20,6 +20,7 @@ pub(crate) enum Endpoint {
     franchises,
     age_ratings,
     player_perspectives,
+    platform_logos,
 }
 
 pub(crate) fn get_endpoint_url(endpoint: &Endpoint) -> String {
@@ -41,5 +42,6 @@ pub(crate) fn get_endpoint_url(endpoint: &Endpoint) -> String {
         Endpoint::franchises => format!("{}/franchises", BASE_URL),
         Endpoint::age_ratings => format!("{}/age_ratings", BASE_URL),
         Endpoint::player_perspectives => format!("{}/player_perspectives", BASE_URL),
+        Endpoint::platform_logos => format!("{}/platform_logos", BASE_URL),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ mod media_macros;
 
 pub mod client;
 pub mod extensions;
+pub mod media_helpers;
 pub mod media_quality;
 pub mod model;
 pub mod request_builder;

--- a/src/media_helpers.rs
+++ b/src/media_helpers.rs
@@ -1,0 +1,44 @@
+use crate::media_quality::MediaQuality;
+use crate::Error;
+
+#[allow(dead_code)]
+///This function receives a path, an IGDB provided url and it normalices the path and downloads
+/// the resource to the specified path file using the specified MediaQuality"
+pub(crate) async fn download_resource(
+    path: String,
+    url: String,
+    quality: MediaQuality,
+) -> Result<(), Error> {
+    use async_std::fs::File;
+    use async_std::io::Write;
+
+    let parsed_url = parse_url(url, quality);
+    log::debug!("Downloading resource: {}", parsed_url);
+
+    let content = surf::get(parsed_url).recv_bytes().await?;
+
+    let mut file = File::create(path).await?;
+    file.write(&content[..]).await?;
+
+    Ok(())
+}
+
+///This function receives a path, an IGDB provided url and it normalices the path and
+///returns the resource content in bytes
+pub(crate) async fn get_resource<S: Into<String>>(
+    url: S,
+    quality: MediaQuality,
+) -> Result<Vec<u8>, Error> {
+    let parsed_url = parse_url(url, quality);
+    let contents = surf::get(parsed_url).recv_bytes().await?;
+    Ok(contents)
+}
+
+pub(crate) fn parse_url<S: Into<String>>(url: S, quality: MediaQuality) -> String {
+    let parsed_url = match url.into() {
+        ref u if !u.starts_with("http") => format!("{}{}", "http:", u),
+        u => u,
+    };
+
+    parsed_url.replace("thumb", &quality.get_value())
+}

--- a/src/media_macros.rs
+++ b/src/media_macros.rs
@@ -17,17 +17,32 @@ macro_rules! expand_media_download {
                 id: usize,
                 path: S,
                 media_quality: MediaQuality,
-            ) -> Result<(), std::io::Error> {
-                let mut request = RequestBuilder::new();
-                request
-                    .all_fields()
-                    .add_where("id", Equality::Equal, id.to_string());
+            ) -> Result<(), Error> {
+                use crate::media_helpers::download_resource;
 
-                //TODO -> Implement std::ops::Try trait in macro clients
-                let covers_response = self.get(request).await.unwrap();
-                let cover = covers_response.first().unwrap();
+                let media = self.get_first_by_id(id).await?;
+                download_resource(path.into(), media.url.clone(), media_quality).await
+            }
+            ///Retrieves content in bytes for the given media resource
+            /// MediaQuality is an enum that specifies different image sizes
+            /// # Examples
+            /// ```no_run
+            /// use igdb_rs::client::IGDBClient;
+            /// use igdb_rs::media_quality::MediaQuality;
+            /// let client = IGDBClient::new("key");
+            /// let screenshot_client = client.screenshots();
+            /// screenshot_client.get_resource_by_id(12400, MediaQuality::ScreenshotHuge,);
+            /// ```
+            ///
+            pub async fn get_resource_by_id(
+                &self,
+                id: usize,
+                media_quality: MediaQuality,
+            ) -> Result<Vec<u8>, Error> {
+                use crate::media_helpers::get_resource;
 
-                download_resource(path.into(), cover.url.clone(), media_quality).await
+                let media = self.get_first_by_id(id).await?;
+                get_resource(media.url.clone(), media_quality).await
             }
         }
     };

--- a/src/media_quality.rs
+++ b/src/media_quality.rs
@@ -1,7 +1,10 @@
 pub enum MediaQuality {
     CoverSmall,
-    ScreenshotMedium,
+    CoverMedium,
     CoverBig,
+    LogoMed,
+    Original,
+    ScreenshotMedium,
     ScreenshotBig,
     ScreenshotHuge,
     Thumb,
@@ -21,8 +24,11 @@ impl MediaQuality {
     pub fn get_value(&self) -> &str {
         match self {
             MediaQuality::CoverSmall => "cover_small",
-            MediaQuality::ScreenshotMedium => "screenshot_med",
+            MediaQuality::CoverMedium => "cover_med",
             MediaQuality::CoverBig => "cover_big",
+            MediaQuality::LogoMed => "logo_med",
+            MediaQuality::Original => "original",
+            MediaQuality::ScreenshotMedium => "screenshot_med",
             MediaQuality::ScreenshotBig => "screenshot_big",
             MediaQuality::ScreenshotHuge => "screenshot_huge",
             MediaQuality::Thumb => "thumb",

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -11,6 +11,7 @@ pub mod game_video;
 pub mod games;
 pub mod multiplayer_mode;
 pub mod platform;
+pub mod platform_logo;
 pub mod player_perspective;
 pub mod release_date;
 pub mod screenshot;

--- a/src/model/platform_logo.rs
+++ b/src/model/platform_logo.rs
@@ -1,0 +1,15 @@
+#[derive(Deserialize, Debug, Clone)]
+pub struct PlatformLogo {
+    #[serde(default)]
+    pub alpha_channel: bool,
+    #[serde(default)]
+    pub animated: bool,
+    #[serde(default)]
+    pub height: usize,
+    #[serde(default)]
+    pub image_id: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub width: usize,
+}


### PR DESCRIPTION
- Refactor internal error handling
- Add platform logos client
- Add get_resource_by_id in media macros to retrieve media as bytes buffers
- Add read media and platform logos download samples

Closes #2 